### PR TITLE
feat: implement git-flash CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,3 @@
----- >8 ----
-!!! FIRST TIME INSTRUCTIONS !!!
-1. The user has initialized this project from a template!  Let's fill in details
-2. Update pyproject.yaml with the project name and description based on the user description
-3. Depending on if this is a library or a command line app, create the scaffolding in PROJECTNAME/ accordingly
-4. Run 'uv lock' to generate a lockfile
-5. Delete these instructions from AGENTS.md, you only run these the first time!
----- >8 ----
 - ONLY use non-interactive commands like cat, sed, apply_patch to do edits.
   Do NOT use interactive editors.
 - Do NOT attempt to install packages.  Only the packages specified in

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# git-flash
+
+git-flash is a command line tool for quickly creating detached git worktree checkouts.
+
+## Usage
+
+```bash
+git-flash OWNER/REPO /path/to/worktree
+```
+
+This command creates a worktree for the specified repository at the given path,
+reusing a global store of repository checkouts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
 [project]
-name = "YOUR_PROJECT"
+name = "git-flash"
 version = "0.1.0"
-description = "YOUR_DESCRIPTION"
+description = "Command line tool for quickly creating detached git worktree checkouts."
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}
 dependencies = [
+    "click>=8.1",
 ]
+
+[project.scripts]
+"git-flash" = "git_flash.cli:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -31,7 +35,7 @@ dev-dependencies = [
 
 [tool.pyrefly]
 project-includes = [
-    "YOUR_PROJECT",
+    "git_flash",
     "tests",
 ]
 project-excludes = [

--- a/src/git_flash/__init__.py
+++ b/src/git_flash/__init__.py
@@ -1,0 +1,5 @@
+"""git-flash package."""
+
+from .cli import flash
+
+__all__ = ["flash"]

--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import configparser
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+GLOBAL_STORE = Path.home() / ".local" / "share" / "git-flash"
+
+
+def _run(args: Iterable[str], cwd: Path | None = None) -> None:
+    subprocess.check_call(list(args), cwd=cwd)
+
+
+def _parse_repo(repo: str) -> tuple[str, Path]:
+    if "://" in repo:
+        url = repo
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", repo)
+        path = GLOBAL_STORE / "extern" / f"{safe}"
+    else:
+        owner, name = repo.split("/", 1)
+        if name.endswith(".git"):
+            name = name[:-4]
+        url = f"https://github.com/{owner}/{name}.git"
+        path = GLOBAL_STORE / "github" / owner / f"{name}.git"
+    return url, path
+
+
+def _ensure_global_repo(url: str, repo_path: Path) -> None:
+    if not repo_path.exists():
+        repo_path.parent.mkdir(parents=True, exist_ok=True)
+        _run(["git", "clone", "--bare", url, str(repo_path)])
+    else:
+        _run(["git", "-C", str(repo_path), "fetch", "--all", "--tags"])
+
+
+def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _run(["git", "-C", str(repo_path), "worktree", "add", "--detach", str(dest), ref])
+
+
+def _get_submodules(dest: Path) -> list[tuple[str, str, str]]:
+    gitmodules = dest / ".gitmodules"
+    if not gitmodules.exists():
+        return []
+    config = configparser.ConfigParser()
+    config.read(gitmodules)
+    subs: list[tuple[str, str, str]] = []
+    for name in config.sections():
+        path = config[name]["path"]
+        url = config[name]["url"]
+        commit = subprocess.check_output(
+            ["git", "rev-parse", f"HEAD:{path}"], cwd=dest, text=True
+        ).strip()
+        subs.append((path, url, commit))
+    return subs
+
+
+def flash(repo: str, destination: Path, ref: str | None = None) -> None:
+    url, repo_path = _parse_repo(repo)
+    _ensure_global_repo(url, repo_path)
+    _worktree_add(repo_path, destination, ref or "HEAD")
+    for path, url, commit in _get_submodules(destination):
+        flash(url, destination / path, commit)
+
+
+@click.command()
+@click.argument("repo")
+@click.argument("destination")
+def main(repo: str, destination: str) -> None:
+    """Flash REPO into DESTINATION using git worktrees."""
+    dest = Path(destination).expanduser().resolve()
+    flash(repo, dest)


### PR DESCRIPTION
## Summary
- configure project metadata and entry point
- add global worktree flashing logic

## Testing
- `uv lock` *(fails: Failed to fetch: `https://pypi.org/simple/pyrefly/`)*
- `ruff format .`
- `ruff check .`
- `pyrefly` *(fails: command not found)*
- `python -m pyrefly` *(fails: No module named pyrefly)*
- `pytest` *(fails: unrecognized arguments: -n)*

## Original Request
```
git-flash is a command line tool for quickly creating detached git worktree checkouts. Follow the first time instructions in AGENTS.md. Spec:

- Use click for command line parsing (add it to pyproject.toml).
- git worktree assumes that you manually create a worktree from an existing git checkout. Instead of manually managing that checkout, git-flash will maintain a global store of checkouts in ~/.local/share/git-flash/. GitHub checkouts will be organized as github/OWNER/NAME.git, while non-GitHub checkouts will be organized via some munging scheme of their URL in extern/. When you say "git-flash pytorch/pytorch ~/pytorch-foo" this will use 'git worktree add' on the global checkout for pytorch/pytorch (assumed to be GitHub with this syntax) to ~/pytorch-foo. We refer to this as "flashing" a checkout (akin to "cloning" it, but faster)
- We handle submodules. After flashing the top level repository, we then traverse the submodules of the checkout and recursively flash their submodules (and so forth).
```

------
https://chatgpt.com/codex/tasks/task_e_688fbf2ca6a08323ac1590ad4ed5f1a0