### PR TITLE
fix: handle missing submodule paths

### DIFF
--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -52,9 +52,12 @@ def _get_submodules(dest: Path) -> list[tuple[str, str, str]]:
     for name in config.sections():
         path = config[name]["path"]
         url = config[name]["url"]
-        commit = subprocess.check_output(
-            ["git", "rev-parse", f"HEAD:{path}"], cwd=dest, text=True
-        ).strip()
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", f"HEAD:{path}"], cwd=dest, text=True
+            ).strip()
+        except subprocess.CalledProcessError:
+            continue
         subs.append((path, url, commit))
     return subs
 

--- a/tests/test_missing_submodule.py
+++ b/tests/test_missing_submodule.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import git_flash.cli as cli
+from git_flash.cli import flash
+
+
+def _git(args, cwd: Path) -> None:
+    subprocess.check_call(["git", *args], cwd=cwd)
+
+
+def test_missing_submodule_is_ignored(tmp_path: Path) -> None:
+    # Use temporary global store to avoid polluting real HOME
+    cli.GLOBAL_STORE = tmp_path / "store"
+
+    # Create submodule repository
+    sub_repo = tmp_path / "sub"
+    sub_repo.mkdir()
+    _git(["init"], sub_repo)
+    (sub_repo / "file.txt").write_text("content")
+    _git(["add", "file.txt"], sub_repo)
+    _git(["commit", "-m", "init"], sub_repo)
+
+    # Create main repository with stale .gitmodules entry
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _git(["init"], main_repo)
+    (main_repo / ".gitmodules").write_text(
+        f'[submodule "missing"]\n\tpath = third-party/googletest\n\turl = {sub_repo.as_uri()}\n'
+    )
+    _git(["add", ".gitmodules"], main_repo)
+    _git(["commit", "-m", "add submodule"], main_repo)
+
+    dest = tmp_path / "checkout"
+    flash(main_repo.as_uri(), dest)
+    assert dest.exists()


### PR DESCRIPTION
## Summary
- ignore submodule entries that refer to paths missing from HEAD
- add regression test for missing submodule paths

## Testing
- `pytest -q -o addopts=`
- `ruff check src/git_flash/cli.py tests/test_missing_submodule.py`
- `pyrefly` *(fails: command not found)*

## Original User Request
I attempted to clone pytorch/pytorch repo using git-flash but it failed with this:

fatal: path 'third-party/googletest' does not exist in 'HEAD'
Traceback (most recent call last):
  File "/data/users/ezyang/git-flash/.venv/bin/git-flash", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/data/users/ezyang/git-flash/.venv/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/ezyang/git-flash/.venv/lib/python3.12/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/data/users/ezyang/git-flash/.venv/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/ezyang/git-flash/.venv/lib/python3.12/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/ezyang/git-flash/src/git_flash/cli.py", line 76, in main
    flash(repo, dest)
  File "/data/users/ezyang/git-flash/src/git_flash/cli.py", line 67, in flash
    flash(url, destination / path, commit)
  File "/data/users/ezyang/git-flash/src/git_flash/cli.py", line 66, in flash
    for path, url, commit in _get_submodules(destination):
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/ezyang/git-flash/src/git_flash/cli.py", line 55, in _get_submodules
    commit = subprocess.check_output(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fbcode/platform010/lib/python3.12/subprocess.py", line 468, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fbcode/platform010/lib/python3.12/subprocess.py", line 573, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'rev-parse', 'HEAD:third-party/googletest']' returned non-zero exit status 128.


------
https://chatgpt.com/codex/tasks/task_e_68910e612a488323a3eab9c36332d3d2