### PR TITLE
fix: clobber local tags on fetch

### DIFF
--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -34,7 +34,7 @@ def _ensure_global_repo(url: str, repo_path: Path) -> None:
         repo_path.parent.mkdir(parents=True, exist_ok=True)
         _run(["git", "clone", "--bare", url, str(repo_path)])
     else:
-        _run(["git", "-C", str(repo_path), "fetch", "--all", "--tags"])
+        _run(["git", "-C", str(repo_path), "fetch", "--all", "--tags", "--force"])
 
 
 def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:

--- a/tests/test_clobber_tags.py
+++ b/tests/test_clobber_tags.py
@@ -1,0 +1,45 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import git_flash.cli as cli
+from git_flash.cli import flash
+
+
+def _git(args, cwd: Path) -> None:
+    subprocess.check_call(["git", *args], cwd=cwd)
+
+
+def test_tags_are_clobbered(tmp_path: Path) -> None:
+    cli.GLOBAL_STORE = tmp_path / "store"
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(["init"], origin)
+    (origin / "file.txt").write_text("one")
+    _git(["add", "file.txt"], origin)
+    _git(["commit", "-m", "one"], origin)
+    _git(["tag", "foo"], origin)
+
+    dest1 = tmp_path / "dest1"
+    flash(origin.as_uri(), dest1)
+
+    (origin / "file.txt").write_text("two")
+    _git(["add", "file.txt"], origin)
+    _git(["commit", "-m", "two"], origin)
+    _git(["tag", "-f", "foo"], origin)
+
+    dest2 = tmp_path / "dest2"
+    flash(origin.as_uri(), dest2)
+
+    _, repo_path = cli._parse_repo(origin.as_uri())
+    tag_commit = subprocess.check_output(
+        ["git", "-C", str(repo_path), "rev-parse", "refs/tags/foo"],
+        text=True,
+    ).strip()
+    head_commit = subprocess.check_output(
+        ["git", "-C", str(origin), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    assert tag_commit == head_commit


### PR DESCRIPTION
## Summary
- Force `git fetch` to overwrite local tags by passing `--force`
- Add regression test ensuring tags are clobbered

## Testing
- `ruff check .`
- `uv run pyrefly check src tests`
- `uv run pytest`

We don't care about local tags, please clobber them.

------
https://chatgpt.com/codex/tasks/task_e_68912ed9c8a88323921f1fb4ab13ab6a