### PR TITLE
fix: skip worktree add when destination exists

### DIFF
--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -39,6 +39,8 @@ def _ensure_global_repo(url: str, repo_path: Path) -> None:
 
 def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return
     _run(["git", "-C", str(repo_path), "worktree", "add", "--detach", str(dest), ref])
 
 


### PR DESCRIPTION
## Summary
- avoid failing when destination already exists by skipping worktree add

## Testing
- `ruff format src/git_flash/cli.py`
- `ruff check src/git_flash/cli.py`
- `pip install pyrefly` *(fails: Could not find a version that satisfies the requirement pyrefly)*
- `python -m pyrefly src/git_flash/cli.py` *(fails: No module named pyrefly)*
- `pip install pytest-xdist` *(fails: Could not find a version that satisfies the requirement pytest-xdist)*
- `pytest --override-ini=addopts=''`

## Original Request
If repo already exist assumes it was cloned correctly and recurse into it.

------
https://chatgpt.com/codex/tasks/task_e_68913095407483239fb8dd8b7adc443c