### PR TITLE
feat: fetch repositories concurrently

### DIFF
--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import configparser
 import re
 import subprocess
@@ -11,8 +12,25 @@ import click
 GLOBAL_STORE = Path.home() / ".local" / "share" / "git-flash"
 
 
-def _run(args: Iterable[str], cwd: Path | None = None) -> None:
-    subprocess.check_call(list(args), cwd=cwd)
+async def _run(args: Iterable[str], cwd: Path | None = None) -> None:
+    cmd = list(args)
+    proc = await asyncio.create_subprocess_exec(*cmd, cwd=str(cwd) if cwd else None)
+    ret = await proc.wait()
+    if ret:
+        raise subprocess.CalledProcessError(ret, cmd)
+
+
+async def _check_output(args: Iterable[str], cwd: Path | None = None) -> str:
+    cmd = list(args)
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=str(cwd) if cwd else None,
+        stdout=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await proc.communicate()
+    if proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, cmd)
+    return stdout.decode().strip()
 
 
 def _parse_repo(repo: str) -> tuple[str, Path]:
@@ -29,22 +47,24 @@ def _parse_repo(repo: str) -> tuple[str, Path]:
     return url, path
 
 
-def _ensure_global_repo(url: str, repo_path: Path) -> None:
+async def _ensure_global_repo(url: str, repo_path: Path) -> None:
     if not repo_path.exists():
         repo_path.parent.mkdir(parents=True, exist_ok=True)
-        _run(["git", "clone", "--bare", url, str(repo_path)])
+        await _run(["git", "clone", "--bare", url, str(repo_path)])
     else:
-        _run(["git", "-C", str(repo_path), "fetch", "--all", "--tags", "--force"])
+        await _run(["git", "-C", str(repo_path), "fetch", "--all", "--tags", "--force"])
 
 
-def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:
+async def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists():
         return
-    _run(["git", "-C", str(repo_path), "worktree", "add", "--detach", str(dest), ref])
+    await _run(
+        ["git", "-C", str(repo_path), "worktree", "add", "--detach", str(dest), ref]
+    )
 
 
-def _get_submodules(dest: Path) -> list[tuple[str, str, str]]:
+async def _get_submodules(dest: Path) -> list[tuple[str, str, str]]:
     gitmodules = dest / ".gitmodules"
     if not gitmodules.exists():
         return []
@@ -55,21 +75,21 @@ def _get_submodules(dest: Path) -> list[tuple[str, str, str]]:
         path = config[name]["path"]
         url = config[name]["url"]
         try:
-            commit = subprocess.check_output(
-                ["git", "rev-parse", f"HEAD:{path}"], cwd=dest, text=True
-            ).strip()
+            commit = await _check_output(["git", "rev-parse", f"HEAD:{path}"], cwd=dest)
         except subprocess.CalledProcessError:
             continue
         subs.append((path, url, commit))
     return subs
 
 
-def flash(repo: str, destination: Path, ref: str | None = None) -> None:
+async def flash(repo: str, destination: Path, ref: str | None = None) -> None:
     url, repo_path = _parse_repo(repo)
-    _ensure_global_repo(url, repo_path)
-    _worktree_add(repo_path, destination, ref or "HEAD")
-    for path, url, commit in _get_submodules(destination):
-        flash(url, destination / path, commit)
+    await _ensure_global_repo(url, repo_path)
+    await _worktree_add(repo_path, destination, ref or "HEAD")
+    subs = await _get_submodules(destination)
+    await asyncio.gather(
+        *(flash(url, destination / path, commit) for path, url, commit in subs)
+    )
 
 
 @click.command()
@@ -78,4 +98,4 @@ def flash(repo: str, destination: Path, ref: str | None = None) -> None:
 def main(repo: str, destination: str) -> None:
     """Flash REPO into DESTINATION using git worktrees."""
     dest = Path(destination).expanduser().resolve()
-    flash(repo, dest)
+    asyncio.run(flash(repo, dest))

--- a/tests/test_clobber_tags.py
+++ b/tests/test_clobber_tags.py
@@ -1,3 +1,4 @@
+import asyncio
 import subprocess
 import sys
 from pathlib import Path
@@ -23,7 +24,7 @@ def test_tags_are_clobbered(tmp_path: Path) -> None:
     _git(["tag", "foo"], origin)
 
     dest1 = tmp_path / "dest1"
-    flash(origin.as_uri(), dest1)
+    asyncio.run(flash(origin.as_uri(), dest1))
 
     (origin / "file.txt").write_text("two")
     _git(["add", "file.txt"], origin)
@@ -31,7 +32,7 @@ def test_tags_are_clobbered(tmp_path: Path) -> None:
     _git(["tag", "-f", "foo"], origin)
 
     dest2 = tmp_path / "dest2"
-    flash(origin.as_uri(), dest2)
+    asyncio.run(flash(origin.as_uri(), dest2))
 
     _, repo_path = cli._parse_repo(origin.as_uri())
     tag_commit = subprocess.check_output(

--- a/tests/test_missing_submodule.py
+++ b/tests/test_missing_submodule.py
@@ -1,3 +1,4 @@
+import asyncio
 import subprocess
 import sys
 from pathlib import Path
@@ -34,5 +35,5 @@ def test_missing_submodule_is_ignored(tmp_path: Path) -> None:
     _git(["commit", "-m", "add submodule"], main_repo)
 
     dest = tmp_path / "checkout"
-    flash(main_repo.as_uri(), dest)
+    asyncio.run(flash(main_repo.as_uri(), dest))
     assert dest.exists()


### PR DESCRIPTION
## Summary
- async subprocess helpers to run git commands without blocking
- `flash` now awaits submodule fetches concurrently via `asyncio.gather`
- tests updated to call new async API

## Testing
- `ruff check`
- `uv run pyrefly check`
- `uv run pytest`

## Original User Request
The current code triggers a fetch on all repos; this ends up being quite slow. Let's parallelize so that all the fetches are done in parallel. Let's do this by async'ifying the codebase.

------
https://chatgpt.com/codex/tasks/task_e_6891334113848323b3de1be7c8c73ac2