### PR TITLE
fix: replace empty directories with submodule worktrees

### DIFF
--- a/src/git_flash/cli.py
+++ b/src/git_flash/cli.py
@@ -58,7 +58,10 @@ async def _ensure_global_repo(url: str, repo_path: Path) -> None:
 async def _worktree_add(repo_path: Path, dest: Path, ref: str) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     if dest.exists():
-        return
+        if dest.is_dir() and not any(dest.iterdir()):
+            dest.rmdir()
+        else:
+            return
     await _run(
         ["git", "-C", str(repo_path), "worktree", "add", "--detach", str(dest), ref]
     )

--- a/tests/test_empty_submodule_dir.py
+++ b/tests/test_empty_submodule_dir.py
@@ -1,0 +1,49 @@
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import git_flash.cli as cli  # noqa: E402
+from git_flash.cli import flash  # noqa: E402
+
+
+def _git(args, cwd: Path) -> None:
+    subprocess.check_call(["git", *args], cwd=cwd)
+
+
+def test_empty_submodule_dir_is_replaced(tmp_path: Path) -> None:
+    cli.GLOBAL_STORE = tmp_path / "store"
+
+    sub_repo = tmp_path / "sub"
+    sub_repo.mkdir()
+    _git(["init"], sub_repo)
+    (sub_repo / "file.txt").write_text("content")
+    _git(["add", "file.txt"], sub_repo)
+    _git(["commit", "-m", "init"], sub_repo)
+
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _git(["init"], main_repo)
+    _git(
+        [
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            sub_repo.as_uri(),
+            "sub",
+        ],
+        main_repo,
+    )
+    _git(["commit", "-m", "add submodule"], main_repo)
+
+    dest = tmp_path / "checkout"
+    asyncio.run(flash(main_repo.as_uri(), dest))
+
+    output = subprocess.check_output(
+        ["git", "submodule", "update", "--init", "--recursive"],
+        cwd=dest,
+        text=True,
+    )
+    assert output.strip() == ""


### PR DESCRIPTION
## Summary
- remove empty directories before creating worktrees so submodules are populated
- add regression test ensuring `git submodule update --init --recursive` is a no-op after flashing

## Testing
- `ruff format .`
- `ruff check .`
- `pyrefly` *(command not found)*
- `pytest -c /dev/null`

## Original Request
After running, there are many submodule folders which are empty. We need to still attempt to create a worktree when there is an empty dir (maybe removing the empty dir first?) The test here is that after git-flash runs, git submodule update --init --recursive should no-op.

------
https://chatgpt.com/codex/tasks/task_e_689171efc2a08323b78e7f125440a8a5